### PR TITLE
Retrieve latest non-development version of composer.phar

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'engineering@copiousinc.com'
 license 'MIT'
 description 'Installs and configures Composer.'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '0.1.0'
+version '0.1.1'
 
 source_url 'https://github.com/copious-cookbooks/composer'
 issues_url 'https://github.com/copious-cookbooks/composer/issues'

--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -7,9 +7,23 @@
 version = node['composer']['install']['version']
 binary  = node['composer']['binary']
 
+# Check if requested version is 'latest'
+if version == 'latest'
+    # Require additional Ruby stdlib packages
+    require 'net/http'
+    require 'json'
+
+    # Craft URI for GitHub API - latest release from composer/composer repository
+    uri = URI('https://api.github.com/repos/composer/composer/releases/latest')
+    # Retrieve JSON response from API
+    response = Net::HTTP.get(uri)
+    # Parse release tag from JSON
+    version = JSON.parse(response)["tag_name"]
+end
+
 remote_file 'install composer binary' do
     path   binary['path']
-    source version == 'latest' ? 'https://getcomposer.org/composer.phar' : "https://getcomposer.org/download/#{version}/composer.phar"
+    source "https://getcomposer.org/download/#{version}/composer.phar"
     owner  binary['user']
     group  binary['group']
     mode   binary['mode']


### PR DESCRIPTION
Presently, `https://getcomposer.org/composer.phar` links to the current latest _development_ version of `composer.phar`. This PR queries the GitHub API for the most recent released version when the Composer version attribute is specified as 'latest'.  Tested on all Kitchen platforms.